### PR TITLE
Casting id's to strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,7 @@ export default function Serializer(
 
     const resourceObject = {
       type,
-      [ref]: refValue,
+      [ref]: String(refValue),
       attributes: IsEmpty(serializedAttributes) ? undefined : serializedAttributes,
       relationships: serializedRelationships,
       links: serializedLinks,

--- a/src/relationships.js
+++ b/src/relationships.js
@@ -11,7 +11,7 @@ function generateRelation(type, ref, refValue) {
   return {
     data: {
       type,
-      [ref]: refValue,
+      [ref]: String(refValue),
     },
   };
 }

--- a/test/unit/relationships.js
+++ b/test/unit/relationships.js
@@ -17,7 +17,7 @@ describe('Relationships', function () {
       expect(result).to.be.an.object();
       expect(result.data).to.be.an.object();
       expect(result.data.type).to.equal('person');
-      expect(result.data.id).to.equal(3);
+      expect(result.data.id).to.equal('3');
 
       done();
     });
@@ -52,7 +52,7 @@ describe('Relationships', function () {
       expect(result).to.be.an.object();
       expect(result.data).to.be.an.object();
       expect(result.data.type).to.equal('address');
-      expect(result.data.id).to.equal(1);
+      expect(result.data.id).to.equal('1');
 
       done();
     });
@@ -76,7 +76,7 @@ describe('Relationships', function () {
       expect(result.data).to.be.an.array();
       expect(result.data.length).to.equal(3);
       expect(result.data[0].type).to.be.a.string();
-      expect(result.data[0].uuid).to.be.a.number();
+      expect(result.data[0].uuid).to.be.a.string();
 
       done();
     });

--- a/test/unit/serializer.js
+++ b/test/unit/serializer.js
@@ -119,7 +119,7 @@ describe('Serializer', function () {
 
         const { id, type, attributes, relationships, links } = jsonapi.data;
 
-        expect(id).to.be.equal(1);
+        expect(id).to.be.equal('1');
         expect(type).to.be.equal('test');
         expect(attributes.name).to.be.equal(data.name);
         expect(attributes.email).to.be.equal(data.email);
@@ -149,7 +149,7 @@ describe('Serializer', function () {
 
         const { id, type, attributes, relationships, links } = jsonapi.data[0];
 
-        expect(id).to.be.equal(1);
+        expect(id).to.be.equal('1');
         expect(type).to.be.equal('test');
         expect(attributes.name).to.be.equal(data[0].name);
         expect(attributes.email).to.be.equal(data[0].email);
@@ -203,7 +203,7 @@ describe('Serializer', function () {
 
         const { id, type, attributes, links, relationships } = jsonapi.data;
 
-        expect(id).to.be.equal(1);
+        expect(id).to.be.equal('1');
         expect(type).to.be.equal('test');
         expect(attributes.name).to.be.equal(data.name);
         expect(attributes.email).to.be.equal(data.email);
@@ -251,14 +251,14 @@ describe('Serializer', function () {
         const address = included[0];
 
         expect(address.type).to.equal(schema.relationships.address.serializer.type);
-        expect(address.id).to.equal(includedPayload.address.id);
+        expect(address.id).to.equal(String(includedPayload.address.id));
 
         const { relationships } = data;
 
         expect(relationships).to.be.an.object();
 
         expect(relationships.address.data.type).to.equal(schema.relationships.address.serializer.type);
-        expect(relationships.address.data.id).to.equal(includedPayload.address.id);
+        expect(relationships.address.data.id).to.equal(String(includedPayload.address.id));
 
         done();
       });
@@ -307,7 +307,7 @@ describe('Serializer', function () {
         const address = included[0];
 
         expect(address.type).to.equal('address');
-        expect(address.id).to.equal(2);
+        expect(address.id).to.equal('2');
         expect(address.attributes.street).to.equal('123 Street Ave.');
         expect(address.attributes.city).to.equal('Lansing');
 
@@ -316,7 +316,7 @@ describe('Serializer', function () {
         expect(relationships).to.be.an.object();
 
         expect(relationships.address.data.type).to.equal('address');
-        expect(relationships.address.data.id).to.equal(2);
+        expect(relationships.address.data.id).to.equal('2');
 
 
         Registry.empty(); // Clean up for the error test later on
@@ -363,7 +363,7 @@ describe('Serializer', function () {
         const address = included[0];
 
         expect(address.type).to.equal('address');
-        expect(address.id).to.equal(2);
+        expect(address.id).to.equal('2');
         expect(address.attributes.street).to.equal('123 Street Ave.');
         expect(address.attributes.city).to.equal('Lansing');
 
@@ -372,7 +372,7 @@ describe('Serializer', function () {
         expect(relationships).to.be.an.object();
 
         expect(relationships.address.data.type).to.equal('address');
-        expect(relationships.address.data.id).to.equal(2);
+        expect(relationships.address.data.id).to.equal('2');
 
         done();
       });
@@ -444,7 +444,7 @@ describe('Serializer', function () {
         expect(relationships.address.data).to.be.an.array();
         expect(relationships.address.data).to.be.length(2);
         expect(relationships.phone.data).to.be.an.object();
-        expect(relationships.phone.data.uuid).to.be.equal(99);
+        expect(relationships.phone.data.uuid).to.be.equal('99');
         expect(relationships.phone.data.type).to.be.equal('phone');
         // TODO(digia): Testing undefined attributes need to be it's own test.
         expect(relationships.phone.data.attributes).to.be.undefined();


### PR DESCRIPTION
Changes to cast all id's from resource identifiers, including relationships, to comply with the JSON API standard. This was discussed in #3. I also updated all test to not-fail when it uses numeric id's since `mocha`/`chai` `.equal('1')` is also checking for variable type.
