### PR TITLE
Pagination links should not go directly in links object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -216,8 +216,14 @@ export default function Serializer(
   function processTopLevelLinks(links) {
     // self: the link that generated the current response document.
     // related: a related resource link when the primary data represents a resource relationship.
-    // pagination: pagination links for the primary data.
-    const topLevelLinks = Pick(links, ['self', 'related', 'pagination']);
+    // pagination: (Deprecated) pagination links for the primary data.
+    // first: the first page of data
+    // last: the last page of data
+    // prev: the previous page of data
+    // next: the next page of data
+    const topLevelLinks = Pick(links, [
+      'self', 'related', 'pagination', 'first', 'last', 'prev', 'next'
+    ]);
 
     if (IsEmpty(topLevelLinks)) {
       return undefined;

--- a/test/unit/serializer.js
+++ b/test/unit/serializer.js
@@ -829,6 +829,39 @@ describe('Serializer', function () {
         done();
       });
 
+      it(`serialize the top level links with pagination`, function (done) {
+        const schema = {
+          attributes: ['name', 'email'],
+        };
+        const serializer = Serializer('test', schema);
+        const meta = {
+          count: 100,
+        };
+        const links = {
+          first: 'http://github.com/digia/jaysonapi?page[number]=1',
+          last: 'http://github.com/digia/jaysonapi?page[number]=3',
+          prev: null,
+          next: 'http://github.com/digia/jaysonapi?page[number]=2',
+        };
+
+        // Include meta for the sake of the standard
+        // Top level must have one of the following: data, errors, meta
+        const jsonapi = serializer.serialize({ meta, links });
+
+        expect(jsonapi).to.be.an.object();
+        expect(jsonapi.data).to.be.undefined();
+        expect(jsonapi.errors).to.be.undefined();
+        expect(jsonapi.includes).to.be.undefined();
+        expect(jsonapi.meta).to.be.an.object();
+        expect(jsonapi.links).to.be.an.object();
+        expect(jsonapi.links.first).to.be.equal(links.first);
+        expect(jsonapi.links.last).to.be.equal(links.last);
+        expect(jsonapi.links.prev).to.be.equal(links.prev);
+        expect(jsonapi.links.next).to.be.equal(links.next);
+
+        done();
+      });
+
       it(`throws TopLevelDocumentError if only links is included`, function (done) {
         const schema = {
           attributes: ['name', 'email'],


### PR DESCRIPTION
This fixes #7. Decided to remove `pagination` but that's a breaking change. Should we keep it?
